### PR TITLE
Fix incorrect allow URL

### DIFF
--- a/aks-hci/config/allow-list-end-points.json
+++ b/aks-hci/config/allow-list-end-points.json
@@ -51,10 +51,6 @@
     "Port": "443",
     "Notes": "Required for AKS on Azure Stack HCI billing when running `Install-AksHci`."
 }, {
-    "URL": "arck8onboarding.azurecr.io",
-    "Port": "443",
-    "Notes": "Required to pull container images when running `Install-AksHci`."
-}, {
     "URL": "v20.events.data.microsoft.com",
     "Port": "443",
     "Notes": "Used periodically to send Microsoft required diagnostic data from the Azure Stack HCI or Windows Server host."


### PR DESCRIPTION
arck8onboarding.azurecr.io is removed from the table in https://github.com/MicrosoftDocs/azure-stack-docs-pr/commit/f9f2b3f93dddd01182f3f6bf2a83f6dda96d63e5